### PR TITLE
Mark Extent, Point and Size as pure

### DIFF
--- a/src/tink/geom2/Extent.hx
+++ b/src/tink/geom2/Extent.hx
@@ -2,6 +2,7 @@ package tink.geom2;
 
 using tink.CoreApi;
 
+@:pure
 abstract Extent(Pair<Float, Float>) {
 
   public var start(get, never):Float;

--- a/src/tink/geom2/Point.hx
+++ b/src/tink/geom2/Point.hx
@@ -2,7 +2,7 @@ package tink.geom2;
 
 import tink.core.Pair;
 
-@:pure 
+@:pure
 abstract Point(Pair<Float, Float>) from Pair<Float, Float> to Pair<Float, Float> {
   public var x(get, never):Float;
   public var y(get, never):Float;

--- a/src/tink/geom2/Size.hx
+++ b/src/tink/geom2/Size.hx
@@ -2,6 +2,7 @@ package tink.geom2;
 
 using tink.CoreApi;
 
+@:pure
 abstract Size(Pair<Float, Float>) {
 
   public var width(get, never):Float;


### PR DESCRIPTION
To be able to use with coconut.data without having to use ' @:skipCheck`.